### PR TITLE
Add devtools options and streamline navigation logic

### DIFF
--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/lib/screens/auth/log_in.dart
+++ b/lib/screens/auth/log_in.dart
@@ -29,9 +29,7 @@ class LogInState extends State<LogIn> {
       AuthUtils.addUserToFirestore(credential.user!.uid, credential.user!.email!, credential.user!.displayName!);
       AuthUtils.onUserLogin();
       if(!context.mounted) return;
-      while (Navigator.canPop(context)) {
-        Navigator.pop(context);
-      }
+      Navigator.popUntil(context, (route) => route.isFirst);
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(builder: (context) => HomeScreen()),

--- a/lib/screens/auth/sign_up.dart
+++ b/lib/screens/auth/sign_up.dart
@@ -51,9 +51,7 @@ class SignUpState extends State<SignUp> {
       await credential.user!.updateDisplayName(username);
       AuthUtils.addUserToFirestore(credential.user!.uid, email, username);
       if(!context.mounted) return;
-      while (Navigator.canPop(context)) {
-        Navigator.pop(context);
-      }
+      Navigator.popUntil(context, (route) => route.isFirst);
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(builder: (context) => HomeScreen()),

--- a/lib/screens/chat/server_settings_screen.dart
+++ b/lib/screens/chat/server_settings_screen.dart
@@ -90,7 +90,7 @@ class ServerSettingsScreen extends StatelessWidget {
                         TextButton(
                           onPressed: () {
                             serverRef.delete();
-                            Navigator.popUntil(context, ModalRoute.withName('/'));
+                            Navigator.popUntil(context, (route) => route.isFirst);
                           },
                           child: const Text('Usuń'),
                         ),

--- a/lib/screens/welcome_screen.dart
+++ b/lib/screens/welcome_screen.dart
@@ -43,9 +43,7 @@ class WelcomeScreenState extends State<WelcomeScreen> {
       AuthUtils.addUserToFirestore(userCredential.user!.uid, userCredential.user!.email!, userCredential.user!.displayName!);
       AuthUtils.onUserLogin();
       if(!context.mounted) return;
-      while(Navigator.canPop(context)) {
-        Navigator.pop(context);
-      }
+      Navigator.popUntil(context, (route) => route.isFirst);
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(builder: (context) => HomeScreen()),


### PR DESCRIPTION
Introduce a configuration file for Dart & Flutter DevTools settings and simplify navigation logic across multiple screens by replacing repetitive pop calls with a single popUntil method.