### PR TITLE
Replace notifications icon with NotificationsButton widget and manage loading state in NotificationsScreen

### DIFF
--- a/lib/screens/chat/friends_screen.dart
+++ b/lib/screens/chat/friends_screen.dart
@@ -1,5 +1,5 @@
-import 'package:flow_chat/screens/chat/notifications.dart';
 import 'package:flow_chat/screens/chat/private_chat_screen.dart';
+import 'package:flow_chat/widgets/notifications_button.dart';
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -125,15 +125,7 @@ class FriendsScreen extends StatelessWidget {
         title: const Text('FlowChat'),
         centerTitle: false,
         actions: [
-          IconButton(
-            icon: const Icon(Icons.notifications),
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(builder: (context) => NotificationsScreen()),
-              );
-            },
-          ),
+          NotificationsButton(userId: FirebaseAuth.instance.currentUser!.uid),
           IconButton(
             icon: const Icon(Icons.add),
             onPressed: () {

--- a/lib/screens/chat/grup_chat_screen.dart
+++ b/lib/screens/chat/grup_chat_screen.dart
@@ -1,10 +1,10 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flow_chat/widgets/notifications_button.dart';
 import 'package:flow_chat/widgets/server_reed_icon.dart';
 import 'package:flutter/material.dart';
 import 'chanels_screen.dart';
 import 'create_server_screen.dart';
-import 'notifications.dart';
 import '../../widgets/bottom_nav_bar.dart';
 
 class HomeScreen extends StatefulWidget {
@@ -41,15 +41,7 @@ class _HomeScreenState extends State<HomeScreen> {
         title: const Text('FlowChat'),
         centerTitle: false,
         actions: [
-          IconButton(
-            icon: const Icon(Icons.notifications),
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(builder: (context) => NotificationsScreen()),
-              );
-            },
-          ),
+          NotificationsButton(userId: FirebaseAuth.instance.currentUser!.uid,),
           IconButton(
             icon: const Icon(Icons.add_home),
             onPressed: () {

--- a/lib/screens/chat/notifications.dart
+++ b/lib/screens/chat/notifications.dart
@@ -2,10 +2,20 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 
-class NotificationsScreen extends StatelessWidget {
+class NotificationsScreen extends StatefulWidget {
   const NotificationsScreen({super.key});
 
+  @override
+  State<NotificationsScreen> createState() => _NotificationsScreenState();
+}
+
+class _NotificationsScreenState extends State<NotificationsScreen> {
+  bool _isLoading = false;
+
   void onAcceptInvite(String inviteId) async {
+    setState(() {
+      _isLoading = true;
+    });
     final invite =
         await FirebaseFirestore.instance
             .collection('invites')
@@ -20,7 +30,7 @@ class NotificationsScreen extends StatelessWidget {
       final server = serverData.data() as Map<String, dynamic>;
       final members = List<String>.from(server['members']);
       members.add(FirebaseAuth.instance.currentUser!.uid);
-      FirebaseFirestore.instance.runTransaction((transaction) async {
+      await FirebaseFirestore.instance.runTransaction((transaction) async {
         transaction.update(
           FirebaseFirestore.instance.collection('teams').doc(invite['from']),
           {'members': members},
@@ -40,7 +50,7 @@ class NotificationsScreen extends StatelessWidget {
               .collection('users')
               .doc(FirebaseAuth.instance.currentUser!.uid)
               .get();
-      FirebaseFirestore.instance.runTransaction((transaction) async {
+      await FirebaseFirestore.instance.runTransaction((transaction) async {
         List<String> privateChatIds = [userData.id, userData2.id];
         transaction.set(
           FirebaseFirestore.instance.collection('private_chats').doc(),
@@ -61,6 +71,9 @@ class NotificationsScreen extends StatelessWidget {
         );
       });
     }
+    setState(() {
+      _isLoading = false;
+    });
   }
 
   void onDeclineInvite(String inviteId) async {
@@ -92,7 +105,7 @@ class NotificationsScreen extends StatelessWidget {
       body: StreamBuilder<QuerySnapshot>(
         stream: invitesStream,
         builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
+          if (snapshot.connectionState == ConnectionState.waiting || _isLoading) {
             return const Center(child: CircularProgressIndicator());
           }
           if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -1,5 +1,5 @@
-import 'package:flow_chat/screens/chat/notifications.dart';
 import 'package:flow_chat/screens/welcome_screen.dart';
+import 'package:flow_chat/widgets/notifications_button.dart';
 import 'package:flutter/material.dart';
 import '../../widgets/bottom_nav_bar.dart';
 import '../../widgets/menu_item_widget.dart';
@@ -26,16 +26,7 @@ class _FlowChatScreenState extends State<FlowChatScreen> {
         title: const Text('FlowChat'),
         centerTitle: false,
         actions: [
-          IconButton(
-            icon: const Icon(Icons.notifications),
-            onPressed:
-                () => Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => const NotificationsScreen(),
-                  ),
-                ),
-          ),
+          NotificationsButton(userId: FirebaseAuth.instance.currentUser!.uid),
         ],
       ),
       body: SafeArea(

--- a/lib/widgets/notifications_button.dart
+++ b/lib/widgets/notifications_button.dart
@@ -1,0 +1,57 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flow_chat/screens/chat/notifications.dart';
+import 'package:flutter/material.dart';
+
+class NotificationsButton extends StatelessWidget {
+  NotificationsButton({super.key, required this.userId});
+  final String userId;
+  late final Stream<QuerySnapshot> _notificationsStream =
+      FirebaseFirestore.instance
+          .collection('invites')
+          .where('to', isEqualTo: userId)
+          .snapshots();
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      icon: Stack(
+        children: [
+          Icon(Icons.notifications),
+          StreamBuilder(
+            stream: _notificationsStream,
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting || !snapshot.hasData || snapshot.data!.docs.isEmpty) {
+                return const SizedBox();
+              }
+              return Positioned(
+                right: 0,
+                child: Container(
+                  padding: const EdgeInsets.all(1),
+                  decoration: BoxDecoration(
+                    color: Colors.red,
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                  constraints: const BoxConstraints(
+                    minWidth: 12,
+                    minHeight: 12,
+                  ),
+                  child: Text(
+                    snapshot.data!.docs.length.toString(),
+                    style: TextStyle(fontSize: 8, fontWeight: FontWeight.bold),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+      onPressed: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (context) => NotificationsScreen()),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
Introduce a new NotificationsButton widget to streamline notifications access across multiple screens and convert NotificationsScreen to a StatefulWidget to handle loading states during invite processing.