### PR TITLE
Add compact message display in chat for consecutive messages

### DIFF
--- a/lib/screens/chat/private_chat_screen.dart
+++ b/lib/screens/chat/private_chat_screen.dart
@@ -75,15 +75,22 @@ class ChatScreenState extends State<PrivateChatScreen> {
                       reverse: true,
                       itemCount: messages.length,
                       itemBuilder: (context, index) {
-                        final message = messages[messages.length - 1 - index];
+                        final messageIndex = messages.length - 1 - index;
+                        final message = messages[messageIndex];
+                        final isCompact = messageIndex == 0 ? false : messages[messageIndex - 1]['name'] == message['name'] && messages[messageIndex - 1]['time'].toDate().difference(message['time'].toDate()).inMinutes < 2;
                         return ChatMessage(
                           name: message['name'],
                           time: message['time'],
                           message: message['message'],
+                          compact: isCompact,
                         );
                       },
                       separatorBuilder:
-                          (context, index) => const SizedBox(height: 10),
+                          (context, index) {
+                            final messageIndex = messages.length - 1 - index;
+                            final isCompact = messageIndex == 0 ? false : messages[messageIndex - 1]['name'] == messages[messageIndex]['name'] && messages[messageIndex - 1]['time'].toDate().difference(messages[messageIndex]['time'].toDate()).inMinutes < 2;
+                            return isCompact ? const SizedBox(height: 0) : const SizedBox(height: 10); 
+                          },
                     );
                   },
                 ),

--- a/lib/widgets/chat_message.dart
+++ b/lib/widgets/chat_message.dart
@@ -3,10 +3,11 @@ import 'package:flow_chat/utils/time_utils.dart';
 import 'package:flutter/material.dart';
 
 class ChatMessage extends StatelessWidget {
-  ChatMessage({super.key, required this.name, required this.time, required this.message});
+  ChatMessage({super.key, required this.name, required this.time, required this.message, this.compact = false});
   final String name;
   final Timestamp time;
   final String message;
+  final bool compact;
   late final _friendStream = FirebaseFirestore.instance.collection('users').doc(name).snapshots();
 
   @override
@@ -18,7 +19,7 @@ class ChatMessage extends StatelessWidget {
       final data = snapshot.data!.data()! as Map<String, dynamic>;
       final name = data['username'] as String;
       final avatarUrl = data['avatarUrl'] as String;
-      return Row(
+      return compact ? Padding(padding: EdgeInsets.only(left: 50), child: Text(message),) : Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         spacing: 10,
         children: [


### PR DESCRIPTION
Introduce a compact display for consecutive messages from the same sender in the chat. This enhancement reduces visual clutter by adjusting the spacing between messages based on sender identity and message timing.