### PR TITLE
Ensure context is mounted before state updates in authentication and loading screens

### DIFF
--- a/lib/screens/auth/log_in.dart
+++ b/lib/screens/auth/log_in.dart
@@ -45,10 +45,10 @@ class LogInState extends State<LogIn> {
         ),
       );
     } on FirebaseAuthException catch (e) {
+      if (!context.mounted) return;
       setState(() {
         _isLoading = false;
       });
-      if (!context.mounted) return;
       if (e.code == 'user-not-found' || e.code == 'wrong-password') {
         ScaffoldMessenger.of(
           context,
@@ -64,6 +64,7 @@ class LogInState extends State<LogIn> {
       }
     } catch (e) {
       print("Error: $e");
+      if(!context.mounted) return;
       setState(() {
         _isLoading = false;
       });

--- a/lib/screens/auth/reset_password.dart
+++ b/lib/screens/auth/reset_password.dart
@@ -29,6 +29,7 @@ class _ResetPasswordState extends State<ResetPassword> {
         if(mounted) ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Wystąpił błąd')));
       }
     }
+    if(!context.mounted) return;
     setState(() {
       _isLoading = false;
     });

--- a/lib/screens/auth/sign_up.dart
+++ b/lib/screens/auth/sign_up.dart
@@ -62,10 +62,10 @@ class SignUpState extends State<SignUp> {
         ),
       );
     } on FirebaseAuthException catch (e) {
+      if (!context.mounted) return;
       setState(() {
         _isLoading = false;
       });
-      if (!context.mounted) return;
       if (e.code == 'weak-password') {
         ScaffoldMessenger.of(
           context,
@@ -87,6 +87,7 @@ class SignUpState extends State<SignUp> {
       }
     } catch (e) {
       print("Error: $e");
+      if (!context.mounted) return;
       setState(() {
         _isLoading = false;
       });

--- a/lib/screens/chat/friends_screen.dart
+++ b/lib/screens/chat/friends_screen.dart
@@ -223,6 +223,7 @@ class _FriendsScreenState extends State<FriendsScreen> {
                           FirebaseAuth.instance.currentUser!.uid,
                         );
                         return ListTile(
+                          titleAlignment: ListTileTitleAlignment.top,
                           trailing:
                               friends[index]['muted'].contains(
                                     FirebaseAuth.instance.currentUser!.uid,

--- a/lib/screens/chat/notifications.dart
+++ b/lib/screens/chat/notifications.dart
@@ -71,6 +71,7 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
         );
       });
     }
+    if (!context.mounted) return;
     setState(() {
       _isLoading = false;
     });

--- a/lib/screens/settings/privacy_and_security_screen.dart
+++ b/lib/screens/settings/privacy_and_security_screen.dart
@@ -156,9 +156,11 @@ class PrivacyAndSecurityScreenState extends State<PrivacyAndSecurityScreen> {
         _emailError = 'Wystąpił błąd przy aktualizacji emaila.';
       });
     } finally {
-      setState(() {
-        _isLoading = false;
-      });
+      if (context.mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
     }
   }
 
@@ -170,8 +172,8 @@ class PrivacyAndSecurityScreenState extends State<PrivacyAndSecurityScreen> {
     });
 
     // Walidacja, czy nowe hasło i potwierdzenie są zgodne
-    if (_newPasswordController.text.trim() !=
-        _confirmNewPasswordController.text.trim()) {
+    if (_newPasswordController.text.trim() != _confirmNewPasswordController.text.trim()) {
+      if (!context.mounted) return;
       setState(() {
         _passwordError = 'Nowe hasło i potwierdzenie nie są zgodne.';
         _isLoading = false;
@@ -217,9 +219,11 @@ class PrivacyAndSecurityScreenState extends State<PrivacyAndSecurityScreen> {
         _passwordError = 'Wystąpił błąd przy aktualizacji hasła.';
       });
     } finally {
-      setState(() {
-        _isLoading = false;
-      });
+      if(context.mounted){
+        setState(() {
+          _isLoading = false;
+        });
+      }
     }
   }
 

--- a/lib/screens/welcome_screen.dart
+++ b/lib/screens/welcome_screen.dart
@@ -51,6 +51,7 @@ class WelcomeScreenState extends State<WelcomeScreen> {
       );
     } catch (e) {
       print("Error: $e");
+      if(!context.mounted) return;
       setState(() {
         _isLoading = false;
       });


### PR DESCRIPTION
Add checks to ensure the context is mounted before performing state updates in various authentication and loading screens to prevent potential errors.