### PR TITLE
Consistent state checks across authentication and loading screens

### DIFF
--- a/lib/screens/auth/log_in.dart
+++ b/lib/screens/auth/log_in.dart
@@ -45,7 +45,7 @@ class LogInState extends State<LogIn> {
         ),
       );
     } on FirebaseAuthException catch (e) {
-      if (!context.mounted) return;
+      if (!mounted) return;
       setState(() {
         _isLoading = false;
       });
@@ -64,7 +64,7 @@ class LogInState extends State<LogIn> {
       }
     } catch (e) {
       print("Error: $e");
-      if(!context.mounted) return;
+      if(!mounted) return;
       setState(() {
         _isLoading = false;
       });

--- a/lib/screens/auth/reset_password.dart
+++ b/lib/screens/auth/reset_password.dart
@@ -29,7 +29,7 @@ class _ResetPasswordState extends State<ResetPassword> {
         if(mounted) ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Wystąpił błąd')));
       }
     }
-    if(!context.mounted) return;
+    if(!mounted) return;
     setState(() {
       _isLoading = false;
     });

--- a/lib/screens/auth/sign_up.dart
+++ b/lib/screens/auth/sign_up.dart
@@ -62,7 +62,7 @@ class SignUpState extends State<SignUp> {
         ),
       );
     } on FirebaseAuthException catch (e) {
-      if (!context.mounted) return;
+      if (!mounted) return;
       setState(() {
         _isLoading = false;
       });
@@ -87,7 +87,7 @@ class SignUpState extends State<SignUp> {
       }
     } catch (e) {
       print("Error: $e");
-      if (!context.mounted) return;
+      if (!mounted) return;
       setState(() {
         _isLoading = false;
       });

--- a/lib/screens/chat/notifications.dart
+++ b/lib/screens/chat/notifications.dart
@@ -71,7 +71,7 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
         );
       });
     }
-    if (!context.mounted) return;
+    if (!mounted) return;
     setState(() {
       _isLoading = false;
     });

--- a/lib/screens/settings/privacy_and_security_screen.dart
+++ b/lib/screens/settings/privacy_and_security_screen.dart
@@ -156,7 +156,7 @@ class PrivacyAndSecurityScreenState extends State<PrivacyAndSecurityScreen> {
         _emailError = 'Wystąpił błąd przy aktualizacji emaila.';
       });
     } finally {
-      if (context.mounted) {
+      if (mounted) {
         setState(() {
           _isLoading = false;
         });
@@ -173,7 +173,7 @@ class PrivacyAndSecurityScreenState extends State<PrivacyAndSecurityScreen> {
 
     // Walidacja, czy nowe hasło i potwierdzenie są zgodne
     if (_newPasswordController.text.trim() != _confirmNewPasswordController.text.trim()) {
-      if (!context.mounted) return;
+      if (!mounted) return;
       setState(() {
         _passwordError = 'Nowe hasło i potwierdzenie nie są zgodne.';
         _isLoading = false;
@@ -219,7 +219,7 @@ class PrivacyAndSecurityScreenState extends State<PrivacyAndSecurityScreen> {
         _passwordError = 'Wystąpił błąd przy aktualizacji hasła.';
       });
     } finally {
-      if(context.mounted){
+      if(mounted){
         setState(() {
           _isLoading = false;
         });

--- a/lib/screens/welcome_screen.dart
+++ b/lib/screens/welcome_screen.dart
@@ -51,7 +51,7 @@ class WelcomeScreenState extends State<WelcomeScreen> {
       );
     } catch (e) {
       print("Error: $e");
-      if(!context.mounted) return;
+      if(!mounted) return;
       setState(() {
         _isLoading = false;
       });


### PR DESCRIPTION
Replace 'context.mounted' with 'mounted' for consistency in state checks across various screens, enhancing code readability and maintainability.